### PR TITLE
fix xy-color-pane define no check

### DIFF
--- a/components/xy-color-picker.js
+++ b/components/xy-color-picker.js
@@ -476,7 +476,9 @@ class XyColorPane extends HTMLElement {
 
 }
 
-customElements.define('xy-color-pane', XyColorPane);
+if(!customElements.get('xy-color-pane')){
+    customElements.define('xy-color-pane', XyColorPane);
+}
 
 export default class XyColorPicker extends HTMLElement {
 


### PR DESCRIPTION
修复在定义xy-color-pane组件的时候未检测该组件是否已定义。