### PR TITLE
fix: 编程式创建 input 标签，在未插入到 DOM的情况下，设置其 value，导致异常

### DIFF
--- a/components/xy-input.js
+++ b/components/xy-input.js
@@ -216,6 +216,7 @@ export default class XyInput extends HTMLElement {
             }
         </xy-tips>
         `
+        this.input = shadowRoot.getElementById('input');
     }
 
     checkValidity(){


### PR DESCRIPTION
在实际使用该UI库的过程中，需要考虑元素未插入到DOM就开始设置一些值的情况，例如：
```js
let checkbox = document.createElement('xy-checkbox');
checkbox.indeterminate = true;
// do something else 
document.body.appendChild(checkbox)
```
以上代码将抛出错误：
`Cannot set property 'indeterminate' of undefined`

> 目前只用 input 做一个示例，如果 OK，再全部理一遍后同步。