### PR TITLE
docs: 修复了vitepress文档头部栏不伸缩的bug

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -19,7 +19,6 @@
   border-color: var(--vp-c-brand);
 }
 :root .VPNav{
-  backdrop-filter: saturate(50%) blur(8px);
   background: rgba(255,255,255,.7);
 }
 :root .VPNavBar.has-sidebar .content-body{


### PR DESCRIPTION
backdrop-filter 应该是用错了，这个属性会改变原来的布局。慎用

下面是之前的bug复现

![QQ录屏20230731132906 00_00_00-00_00_30](https://github.com/XboxYan/xy-ui/assets/59329360/782d4186-4a37-4f45-a082-a58e8b440cf3)

这是删掉了 backdrop-filter 之后的效果

![QQ录屏20230731134837 00_00_00-00_00_30](https://github.com/XboxYan/xy-ui/assets/59329360/9e15a16c-b732-4aec-920a-80224a8d3d7c)

